### PR TITLE
improve messaging when PR is not merged

### DIFF
--- a/bin/revert
+++ b/bin/revert
@@ -19,6 +19,14 @@ def get_merge_commit_sha(
         headers=headers,
     )
     contents = json.load(urllib.request.urlopen(req, timeout=15))
+
+    if not contents['merged']:
+        raise SystemExit(
+            '\n'
+            'pr is not merged!\n'
+            'instead run the action on the merged PR',
+        )
+
     sha = contents.get('merge_commit_sha')
     if sha:
         return sha


### PR DESCRIPTION
tested locally:

```console
$ ./bin/revert --dry-run --repo-id 873328 --repo-dir ../sentry --pr 41561 --co-authored-by 'asottile' --committer-email 'anthony.sottile@sentry.io' --committer-name 'asottile'
figuring out what to revert...

pr is not merged!
apply the label instead to the already-merged PR
```