### PR TITLE
feat: Nudge the reverter to leave a comment after reverting

### DIFF
--- a/bin/revert
+++ b/bin/revert
@@ -41,7 +41,12 @@ def post_comment(
         revert_sha: str,
         headers: dict[str, str],
 ) -> None:
-    data = {'body': f'PR reverted: {revert_sha}'}
+    data = {
+        'body': (
+            f'PR reverted: {revert_sha}.\n\n'
+            f'Did you leave a comment describing why this PR was reverted?'
+        ),
+    }
     req = urllib.request.Request(
         f'https://api.github.com/repositories/{repo_id}/issues/{pr}/comments',
         method='POST',


### PR DESCRIPTION
We would like for people to indicate WHY they reverted a PR. Since right now it's not uncommon to start the work day, see one of your PRs was reverted, and ask the question "why was this reverted?". You'll have to track down the person who did the revert, and you'll be lucky if they're online.

This adds an additional line to the revert comment asking the reverter to leave a comment describing why the PR was reverted.